### PR TITLE
Should not present variable for auto-population to work

### DIFF
--- a/charts/helpy/Chart.yaml
+++ b/charts/helpy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: helpy
 description: Installs a production cluster of Helpy or Helpy Pro
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "3.2.7"
 home: https://helpy.io/
 sources:

--- a/charts/helpy/values.yaml
+++ b/charts/helpy/values.yaml
@@ -49,7 +49,7 @@ rails:
   serveStaticFiles: false
   pumaConcurency: '1'
   podRam: '1024'
-  secretKey: ''
+  # secretKey: ''
   sessionDuration: 20
   sessionStore: 'cookie'
 


### PR DESCRIPTION
We have to fully remove the variable in order for the env to autoset the secret base.  